### PR TITLE
hide score table and renamed game to gameCard

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,21 +24,25 @@
 }
 
 .game {
+  background-color: lightgreen;
+  padding: 8px 8px;
   border: 1px solid #282c34;
   display: inline-block;
 }
 
 .game:hover{
-  background: lightgreen; 
+  background: rgba(91, 196, 91, 0.973); 
 }
 
 .player {
+  background-color: rgb(255, 255, 153);
+  padding: 8px 8px;
   border: 1px solid #282c34;
   display: inline-block;
 }
 
 .player:hover{
-  background: lightgoldenrodyellow; 
+  background: rgb(247, 247, 95); 
 }
 
 table, th, td {
@@ -46,15 +50,28 @@ table, th, td {
 }
 
 table {
-  table-layout: fixed ;
-  width: 100% ;
+  margin: 20px;
+  align-self: center;
+  border-collapse: collapse;
+  table-layout: fixed;
+  width: 100%;
+  border-spacing: 2px;
+}
+
+th {
+  background-color: rgb(226, 119, 119);
 }
 
 td {
-  width: 25% ;
+  width: 20% ;
+  background-color: rgb(230, 195, 195);
 }
 
-.button {
+.hidden {
+  display: none;
+}
+
+.smallButton {
   background-color: #4CAF50; /* Green */
   border: none;
   color: white;
@@ -75,7 +92,33 @@ td {
   border: 1px solid #4CAF50;
 }
 
+
 .button1:hover {
   background-color: #4CAF50;
+  color: white;
+}
+
+.largeButton {
+  border: none;
+  color: white;
+  padding: 8px 8px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 18px;
+  margin: 2px 2px;
+  -webkit-transition-duration: 0.4s; /* Safari */
+  transition-duration: 0.4s;
+  cursor: pointer;
+}
+
+.button2 {
+  background-color:  rgb(230, 195, 195);
+  color: black; 
+  border: 1px solid rgb(228, 82, 82); 
+}
+
+.button2:hover {
+  background-color: rgb(228, 82, 82); 
   color: white;
 }

--- a/src/Components/GameCard.js
+++ b/src/Components/GameCard.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-function Game({ game }) {
+function GameCard({ game }) {
   return (
     <div className="game">
       <div className="title">
@@ -11,18 +11,25 @@ function Game({ game }) {
         </strong>
       </div>
       <div>{game.date}</div>
-      {game.complete && (
-        <>
-          <div>OU {game.ouWon ? "won" : "lost"}</div>
-          <div>
-            {game.ouScore} to {game.oppScore}
-          </div>
-          <div>Guessed Winner: {game.guessedWinner.join(", ")}</div>
-          <div>Closest to OU score: {game.closestOu.join(", ")}</div>
-          <div>Closest to Opp score: {game.closestOpp.join(", ")}</div>
-        </>
-      )}
-    <button class="button button1" onClick={() =>
+      {
+        game.complete ? 
+        (
+          <>
+            <div>OU {game.ouWon ? "won" : "lost"}</div>
+            <div>
+              {game.ouScore} to {game.oppScore}
+            </div>
+          </>
+        ) 
+        : 
+        (
+          <>
+          <br></br>
+          <br></br>
+          </>
+        )
+      }
+    <button class="smallButton button1" onClick={() =>
         window.open(
           "https://www.espn.com/college-football/game/_/gameId/" +
             game.espnGameId
@@ -32,7 +39,7 @@ function Game({ game }) {
   );
 }
 
-export default Game;
+export default GameCard;
 
 //urls
 //Houston: https://www.espn.com/college-football/game/_/gameId/401112114

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { connect } from "react-redux";
-import Game from "./Game";
+import GameCard from "./GameCard";
 import PlayerCard from "./PlayerCard";
 import PredictionsTable from "./PredictionsTable";
 
@@ -14,7 +14,7 @@ function Home({ Outcome }) {
       <br></br>
       <div id="GamesDiv">
         {Outcome.outcome.scores.map(game => (
-          <Game key={game.id} game={game}></Game>
+          <GameCard key={game.id} game={game}></GameCard>
         ))}
       </div>
       <br></br>
@@ -28,11 +28,24 @@ function Home({ Outcome }) {
         ))}
       </div>
       <br></br>
+      <button class="largeButton button2" onClick={() => showHideScores()}>Show/Hide Scores</button>
+      <br></br>
+      <br></br>
       <div id="ScoresDiv">
         <PredictionsTable players={Outcome.outcome.players} games={Outcome.outcome.scores}></PredictionsTable>
       </div>
     </div>
   );
+}
+
+function showHideScores()
+{
+  var x = document.getElementById("scoresTable");
+  if (x.classList.contains("hidden")) {
+    x.classList.remove('hidden');
+  } else {
+    x.classList.add('hidden');
+  }
 }
 
 const mapStateToProps = state => ({

--- a/src/Components/PlayerCard.js
+++ b/src/Components/PlayerCard.js
@@ -7,7 +7,7 @@ function PlayerCard({ player, playerClicked }) {
         <strong>{player.name}</strong>
       </div>
       <div>
-        Player Score:
+        Points: 
         {player.totalScore}
       </div>
     </div>

--- a/src/Components/PredictionsTable.js
+++ b/src/Components/PredictionsTable.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 export default ({ players, games }) => (
-  <table align="center">
+  <table id="scoresTable" class="hidden">
     {GetTableHeaders(games)}
     {GetPlayerPredictions(players)}
   </table>


### PR DESCRIPTION
Bad branch name, no highlighting on clicks yet 👎 

Table is minimized by default, clicking something expands it - for cleaner overall look. Or have a link to /data to show the table

don't show who all guessed the game correctly - makes the game cards too big. you get the same data by clicking a game

rename game component to GameCard to match PlayerCard naming